### PR TITLE
Egui plot integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.41", features = ["derive"] }
-egui = { version = "0.32.0", features = ["default_fonts"] }
+egui = { version = "0.31.0", features = ["default_fonts"] }
+egui_plot = "0.32.1"
 egui_winit_vulkano = "0.28.0"
 image = "0.25.6"
+memory-stats = "1.2.0"
 sysinfo = "0.36.0"
 vulkano = { version = "0.35.1", features = ["macros"] }
 vulkano-shaders = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ egui = { version = "0.31.0", features = ["default_fonts"] }
 egui_plot = "0.32.1"
 egui_winit_vulkano = "0.28.0"
 image = "0.25.6"
-memory-stats = "1.2.0"
 sysinfo = "0.36.0"
 vulkano = { version = "0.35.1", features = ["macros"] }
 vulkano-shaders = "0.35.0"

--- a/src/engine/ui/debug_ui.rs
+++ b/src/engine/ui/debug_ui.rs
@@ -1,40 +1,53 @@
-use egui_plot::{log_grid_spacer, uniform_grid_spacer, GridInput, Line, Plot, PlotPoints};
-use egui_winit_vulkano::egui::{self, Context, FontDefinitions, ProgressBar, RichText};
-use memory_stats::{self, MemoryStats};
+use egui_plot::{uniform_grid_spacer, Line, Plot, PlotPoints};
+use egui::{self, Context, FontDefinitions, RichText};
 use std::{collections::VecDeque, sync::Arc};
-use sysinfo::System;
+use sysinfo::{Process, System};
 use vulkano::device::Queue;
 
-use crate::engine::ui::egui_integration::EguiStruct;
+type MemoryUsageBytes = u64;
+type CpuUsagePercent = f64;
+
+const AMOUNT_OF_STATS_SAVED: u64 = 1024;
 
 pub struct DebugUi {
     pub queue: Arc<Queue>,
-    mem_usage_stats: VecDeque<Option<MemoryStats>>,
+    mem_usage_stats: VecDeque<Option<MemoryUsageBytes>>,
+    cpu_usage_stats: VecDeque<Option<CpuUsagePercent>>,
 }
 
 impl DebugUi {
     pub fn new(queue: Arc<Queue>) -> Self {
-        let mut mem_usage: VecDeque<Option<MemoryStats>> = VecDeque::with_capacity(128);
-        mem_usage.resize_with(128, || None);
+        let mut mem_usage: VecDeque<Option<MemoryUsageBytes>> = VecDeque::with_capacity(AMOUNT_OF_STATS_SAVED as usize);
+        mem_usage.resize_with(AMOUNT_OF_STATS_SAVED as usize, || None);
+
+        let mut cpu_usage: VecDeque<Option<CpuUsagePercent>> = VecDeque::with_capacity(AMOUNT_OF_STATS_SAVED as usize);
+        cpu_usage.resize_with(AMOUNT_OF_STATS_SAVED as usize, || None);
 
         DebugUi {
             queue,
             mem_usage_stats: mem_usage,
+            cpu_usage_stats: cpu_usage,
         }
     }
 
     // has an implicit lifetime due to using a System ref. Doesn't do much though.
     pub fn render(&mut self, ctx: &Context, system: &System) {
-        
         ctx.set_fonts(FontDefinitions::default());
 
         egui::Window::new("Despawn Debugger")
             .resizable(true)
             .show(ctx, |ui| {
+                let proc = system
+                    .process(sysinfo::get_current_pid().expect("Failed to get current Pid"))
+                    .expect("Failed to get current process");
+
                 // System Info Header
                 ui.heading("System Information");
 
                 // CPU Info and Usage
+
+                self.update_cpu_usage(proc);
+
                 egui::CollapsingHeader::new("CPU")
                     .default_open(false)
                     .show(ui, |ui| {
@@ -47,17 +60,35 @@ impl DebugUi {
 
                         ui.add_space(5.0);
                         ui.label(RichText::new(format!("Model: {}", cpu.0)).strong());
-                        ui.label(format!("Cores: {}", cpu_cores));
-                        ui.add(
-                            ProgressBar::new(cpu.1 / 100.0)
-                                .text(format!("Usage: {:.1}%", cpu.1))
-                                .desired_width(250.0),
-                        );
+
+                        let cpu_usage: PlotPoints = self
+                            .cpu_usage_stats
+                            .clone()
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, value)| {
+                                let x = value.unwrap_or_default();
+                                [index as f64, x]
+                            })
+                            .collect();
+                        Plot::new("my_plot")
+                            .view_aspect(2.0)
+                            .allow_zoom(false)
+                            .allow_scroll(false)
+                            .allow_drag(false)
+                            .allow_boxed_zoom(false)
+                            .allow_double_click_reset(false)
+                            .x_grid_spacer(uniform_grid_spacer(|_| [AMOUNT_OF_STATS_SAVED as f64 / 16.0, AMOUNT_OF_STATS_SAVED as f64 / 4.0, AMOUNT_OF_STATS_SAVED as f64 / 2.0]))
+                            .default_y_bounds(0.0, 100.0)
+                            .default_x_bounds(0.0, AMOUNT_OF_STATS_SAVED as f64)
+                            .show(ui, |plot_ui| {
+                                plot_ui.line(Line::new("Cpu Usage Percentage", cpu_usage))
+                            });
                     });
 
                 // RAM Info and Usage
-                //
-                self.update_memory_usage();
+
+                self.update_memory_usage(proc);
 
                 let total_memory = system.total_memory();
                 egui::CollapsingHeader::new("Memory")
@@ -78,10 +109,7 @@ impl DebugUi {
                             .into_iter()
                             .enumerate()
                             .map(|(index, value)| {
-                                let x = match value {
-                                    Some(memory_data) => memory_data.physical_mem,
-                                    None => 0_usize,
-                                };
+                                let x = value.unwrap_or_default();
                                 [index as f64, x as f64 / total_memory as f64 * 100.0]
                             })
                             .collect();
@@ -92,9 +120,9 @@ impl DebugUi {
                             .allow_drag(false)
                             .allow_boxed_zoom(false)
                             .allow_double_click_reset(false)
-                            .x_grid_spacer(uniform_grid_spacer(|_| {[4.0, 16.0, 64.0]}))
+                            .x_grid_spacer(uniform_grid_spacer(|_| [AMOUNT_OF_STATS_SAVED as f64 / 16.0, AMOUNT_OF_STATS_SAVED as f64 / 4.0, AMOUNT_OF_STATS_SAVED as f64 / 2.0]))
                             .default_y_bounds(0.0, 100.0)
-                            .default_x_bounds(0.0, 128.0)
+                            .default_x_bounds(0.0, AMOUNT_OF_STATS_SAVED as f64)
                             .show(ui, |plot_ui| {
                                 plot_ui.line(Line::new("Memory Usage Percentage", mem_usage))
                             });
@@ -120,9 +148,14 @@ impl DebugUi {
             });
     }
 
-    fn update_memory_usage(&mut self) {
-        let latest_memory_stats = memory_stats::memory_stats();
+    fn update_memory_usage(&mut self, process: &Process) {
+        let latest_memory_stats: MemoryUsageBytes = process.memory();
         self.mem_usage_stats.pop_front();
-        self.mem_usage_stats.extend(Some(latest_memory_stats));
+        self.mem_usage_stats.extend([Some(latest_memory_stats)]);
+    }
+    fn update_cpu_usage(&mut self, process: &Process) {
+        let latest_cpu_usage: CpuUsagePercent = process.cpu_usage() as f64;
+        self.cpu_usage_stats.pop_front();
+        self.cpu_usage_stats.extend([Some(latest_cpu_usage)]);
     }
 }

--- a/src/engine/ui/debug_ui.rs
+++ b/src/engine/ui/debug_ui.rs
@@ -1,65 +1,128 @@
-use egui_winit_vulkano::egui::{self, Context, RichText, FontDefinitions, ProgressBar};
+use egui_plot::{log_grid_spacer, uniform_grid_spacer, GridInput, Line, Plot, PlotPoints};
+use egui_winit_vulkano::egui::{self, Context, FontDefinitions, ProgressBar, RichText};
+use memory_stats::{self, MemoryStats};
+use std::{collections::VecDeque, sync::Arc};
 use sysinfo::System;
-use std::sync::Arc;
 use vulkano::device::Queue;
 
-pub struct DebugUi<'a> {
-    pub system: &'a System,
+use crate::engine::ui::egui_integration::EguiStruct;
+
+pub struct DebugUi {
     pub queue: Arc<Queue>,
+    mem_usage_stats: VecDeque<Option<MemoryStats>>,
 }
 
-impl<'a> DebugUi<'a> {
-    pub fn render(&self, ctx: &Context) {
+impl DebugUi {
+    pub fn new(queue: Arc<Queue>) -> Self {
+        let mut mem_usage: VecDeque<Option<MemoryStats>> = VecDeque::with_capacity(128);
+        mem_usage.resize_with(128, || None);
+
+        DebugUi {
+            queue,
+            mem_usage_stats: mem_usage,
+        }
+    }
+
+    // has an implicit lifetime due to using a System ref. Doesn't do much though.
+    pub fn render(&mut self, ctx: &Context, system: &System) {
+        
         ctx.set_fonts(FontDefinitions::default());
 
-        egui::Window::new("Despawn Debugger").resizable(true).show(ctx, |ui| {
-            // System Info Header
-            ui.heading("System Information");
+        egui::Window::new("Despawn Debugger")
+            .resizable(true)
+            .show(ctx, |ui| {
+                // System Info Header
+                ui.heading("System Information");
 
-            // CPU Info and Usage
-            egui::CollapsingHeader::new("CPU")
-                .default_open(false)
-                .show(ui, |ui| {
-                    let cpu = self.system.cpus().first()
-                        .map(|cpu| (cpu.brand(), cpu.cpu_usage()))
-                        .unwrap_or(("Unknown", 0.0));
-                    let cpu_cores = self.system.cpus().len();
+                // CPU Info and Usage
+                egui::CollapsingHeader::new("CPU")
+                    .default_open(false)
+                    .show(ui, |ui| {
+                        let cpu = system
+                            .cpus()
+                            .first()
+                            .map(|cpu| (cpu.brand(), cpu.cpu_usage()))
+                            .unwrap_or(("Unknown", 0.0));
+                        let cpu_cores = system.cpus().len();
 
-                    ui.add_space(5.0);
-                    ui.label(RichText::new(format!("Model: {}", cpu.0)).strong());
-                    ui.label(format!("Cores: {}", cpu_cores));
-                    ui.add(ProgressBar::new(cpu.1 / 100.0)
-                        .text(format!("Usage: {:.1}%", cpu.1))
-                        .desired_width(250.0));
-                });
+                        ui.add_space(5.0);
+                        ui.label(RichText::new(format!("Model: {}", cpu.0)).strong());
+                        ui.label(format!("Cores: {}", cpu_cores));
+                        ui.add(
+                            ProgressBar::new(cpu.1 / 100.0)
+                                .text(format!("Usage: {:.1}%", cpu.1))
+                                .desired_width(250.0),
+                        );
+                    });
 
-            // RAM Info and Usage
-            egui::CollapsingHeader::new("Memory")
-                .default_open(false)
-                .show(ui, |ui| {
-                    let total_memory = self.system.total_memory();
-                    let used_memory = self.system.used_memory();
-                    let ram_usage = (used_memory as f64 / total_memory as f64) * 100.0;
+                // RAM Info and Usage
+                //
+                self.update_memory_usage();
 
-                    ui.add_space(5.0);
-                    ui.label(RichText::new(format!("Total: {:.1} GB", total_memory as f64 / 1_073_741_824.0)).strong());
-                    ui.label(format!("Used: {:.1} GB ({:.1}%)", used_memory as f64 / 1_073_741_824.0, ram_usage));
-                    ui.add(ProgressBar::new(ram_usage as f32 / 100.0)
-                        .text(format!("{:.1}%", ram_usage))
-                        .desired_width(250.0));
-                });
+                let total_memory = system.total_memory();
+                egui::CollapsingHeader::new("Memory")
+                    .default_open(false)
+                    .show(ui, |ui| {
+                        ui.add_space(5.0);
+                        ui.label(
+                            RichText::new(format!(
+                                "Total: {:.1} GiB",
+                                total_memory as f64 / 1_073_741_824.0
+                            ))
+                            .strong(),
+                        );
 
-            // GPU Info (from Vulkan)
-            egui::CollapsingHeader::new("GPU")
-                .default_open(false)
-                .show(ui, |ui| {
-                    let gpu_name = self.queue.device().physical_device().properties().device_name.to_string();
-                    ui.add_space(5.0);
-                    ui.label(RichText::new(format!("Model: {}", gpu_name)).strong());
-                });
+                        let mem_usage: PlotPoints = self
+                            .mem_usage_stats
+                            .clone()
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, value)| {
+                                let x = match value {
+                                    Some(memory_data) => memory_data.physical_mem,
+                                    None => 0_usize,
+                                };
+                                [index as f64, x as f64 / total_memory as f64 * 100.0]
+                            })
+                            .collect();
+                        Plot::new("my_plot")
+                            .view_aspect(2.0)
+                            .allow_zoom(false)
+                            .allow_scroll(false)
+                            .allow_drag(false)
+                            .allow_boxed_zoom(false)
+                            .allow_double_click_reset(false)
+                            .x_grid_spacer(uniform_grid_spacer(|_| {[4.0, 16.0, 64.0]}))
+                            .default_y_bounds(0.0, 100.0)
+                            .default_x_bounds(0.0, 128.0)
+                            .show(ui, |plot_ui| {
+                                plot_ui.line(Line::new("Memory Usage Percentage", mem_usage))
+                            });
+                    });
 
-            // Game Specifics Header
-            ui.heading("Game Specifics");
-        });
+                // GPU Info (from Vulkan)
+                egui::CollapsingHeader::new("GPU")
+                    .default_open(false)
+                    .show(ui, |ui| {
+                        let gpu_name = self
+                            .queue
+                            .device()
+                            .physical_device()
+                            .properties()
+                            .device_name
+                            .to_string();
+                        ui.add_space(5.0);
+                        ui.label(RichText::new(format!("Model: {}", gpu_name)).strong());
+                    });
+
+                // Game Specifics Header
+                ui.heading("Game Specifics");
+            });
+    }
+
+    fn update_memory_usage(&mut self) {
+        let latest_memory_stats = memory_stats::memory_stats();
+        self.mem_usage_stats.pop_front();
+        self.mem_usage_stats.extend(Some(latest_memory_stats));
     }
 }

--- a/src/engine/ui/egui_integration.rs
+++ b/src/engine/ui/egui_integration.rs
@@ -1,21 +1,20 @@
-use crate::engine::{rendering::vswapchain::IMAGE_FORMAT, ui::debug_ui};
+use crate::engine::rendering::vswapchain::IMAGE_FORMAT;
 use crate::engine::ui::debug_ui::DebugUi;
-use egui_winit_vulkano::{
-    egui::{self, FontDefinitions},
-    Gui, GuiConfig,
-};
+use egui_winit_vulkano::{Gui, GuiConfig};
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use sysinfo::System;
+use sysinfo::{Process, System};
 use vulkano::{
     command_buffer::SecondaryAutoCommandBuffer, device::Queue, render_pass::Subpass,
     swapchain::Surface,
 };
+
 use winit::{event::WindowEvent, event_loop::ActiveEventLoop};
 
 pub struct EguiStruct {
     gui: Gui,
-    pub system: System,
+    system: System,
     queue: Arc<Queue>, // For GPU info
     last_update: Instant,
     update_interval: Duration, // frequently to update the UI window
@@ -44,9 +43,7 @@ impl EguiStruct {
 
         system.refresh_all(); // Initial refresh
 
-
         let debug_ui = DebugUi::new(queue.clone());
-
         EguiStruct {
             gui: egui,
             system,


### PR DESCRIPTION
Downgrades version of egui to enable egui_plot crate to work with egui_winit_vulkano crate, which was already kinda broken-ish using the newer version.